### PR TITLE
Fix auto-connect button not persisting after refreshing the page

### DIFF
--- a/src/components/AppBar.tsx
+++ b/src/components/AppBar.tsx
@@ -73,7 +73,7 @@ export const AppBar: FC = props => {
               <li>
                 <div className="form-control">
                   <label className="cursor-pointer label">
-                    <a>Autoconnect</a>
+                    <a>Auto-connect</a>
                     <input type="checkbox" checked={autoConnect} onChange={(e) => setAutoConnect(e.target.checked)} className="toggle" />
                   </label>
                 </div>

--- a/src/contexts/AutoConnectProvider.tsx
+++ b/src/contexts/AutoConnectProvider.tsx
@@ -1,9 +1,8 @@
-import { useLocalStorage } from '@solana/wallet-adapter-react';
-import { createContext, FC, ReactNode, useContext } from 'react';
+import { createContext, Dispatch, FC, ReactNode, SetStateAction, useCallback, useContext, useEffect, useState } from 'react';
 
 export interface AutoConnectContextState {
     autoConnect: boolean;
-    setAutoConnect(autoConnect: boolean): void;
+    setAutoConnect: Dispatch<SetStateAction<boolean>>;
 }
 
 export const AutoConnectContext = createContext<AutoConnectContextState>({} as AutoConnectContextState);
@@ -13,10 +12,17 @@ export function useAutoConnect(): AutoConnectContextState {
 }
 
 export const AutoConnectProvider: FC<{ children: ReactNode }> = ({ children }) => {
-    // TODO: fix auto connect to actual reconnect on refresh/other.
-    // TODO: make switch/slider settings
-    // const [autoConnect, setAutoConnect] = useLocalStorage('autoConnect', false);
-    const [autoConnect, setAutoConnect] = useLocalStorage('autoConnect', true);
+    const [autoConnect, setAutoConnect] = useState<boolean>(() => {
+        if (typeof window !== 'undefined') {
+          const value = localStorage.getItem('auto-connect')
+    
+          return JSON.parse(value)
+        }
+    });
+
+    useEffect(() => {
+        localStorage.setItem('auto-connect', JSON.stringify(autoConnect))
+    },[autoConnect])
 
     return (
         <AutoConnectContext.Provider value={{ autoConnect, setAutoConnect }}>{children}</AutoConnectContext.Provider>

--- a/src/contexts/AutoConnectProvider.tsx
+++ b/src/contexts/AutoConnectProvider.tsx
@@ -13,11 +13,10 @@ export function useAutoConnect(): AutoConnectContextState {
 
 export const AutoConnectProvider: FC<{ children: ReactNode }> = ({ children }) => {
     const [autoConnect, setAutoConnect] = useState<boolean>(() => {
-        if (typeof window !== 'undefined') {
+        if (typeof window === 'undefined') return false
           const value = localStorage.getItem('auto-connect')
     
-          return JSON.parse(value)
-        }
+          return value ? JSON.parse(value) : false
     });
 
     useEffect(() => {


### PR DESCRIPTION
The problem with the current auto-connect feature is that it only saves the user preference on the current state, not persisting after refreshing the page.

This PR solves the issue (#23) by saving the auto-connect preference on local storage. 